### PR TITLE
Just return query output if bindings is empty

### DIFF
--- a/src/QueryLogServiceProvider.php
+++ b/src/QueryLogServiceProvider.php
@@ -57,6 +57,10 @@ class QueryLogServiceProvider extends ServiceProvider
      */
     private function insertBindingsIntoQuery($query, $bindings)
     {
+        if (empty($bindings)) {
+            return $query;
+        }
+        
         $query = str_replace(array('%', '?'), array('%%', '%s'), $query);
 
         return vsprintf($query, $bindings);


### PR DESCRIPTION
### Fixed
- Fix a crash when trying to execute a query when there are no bindings

---

In some cases when using MongoDB this would crash when doing an insert query since no bindings are passed.
